### PR TITLE
Add Google Drive SDK Demo app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 android:
   components:
   - tools
-  - build-tools-24.0.2
+  - build-tools-24.0.3
   - android-24
   - extra-google-google_play_services
   - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ jdk:
 android:
   components:
   - tools
-  - build-tools-23.0.3
+  - build-tools-24.0.2
   - android-24
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
   - addon-google_apis-google-24
 script:
-- "./gradlew clean test --continue"
+  - "./gradlew clean test --continue"
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The Lock-GooglePlus is available through [Maven Central](http://search.maven.org
 compile 'com.auth0.android:lock-googleplus:2.5.+'
 ```
 
-Then in your project's `AndroidManifest.xml` add the following entry:
+Then in your project's `AndroidManifest.xml` add the following entry inside the application tag.
 
 ```xml
 <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
@@ -129,13 +129,29 @@ To use a custom social connection name to authorize against Auth0, call `setConn
 provider.setConnection("my-connection")
 ```
 
+## Requesting a custom Scope
+By default, the scope `Scopes.PLUS_LOGIN` is requested. You can customize the Scopes by calling `setScopes` with the list of Scopes. Each Google API (Auth, Drive, Plus..) specify it's own list of Scopes.
+
+```java
+provider.setScopes(Arrays.asList(new Scope(Scopes.PLUS_ME), new Scope(Scopes.PLUS_LOGIN)));
+```
+
+## Using custom Android Runtime Permissions
+This provider doesn't require any special Android Manifest Permission to authenticate the user. But if your use case requires them, you can let the AuthProvider handle them for you. Use the `setRequiredPermissions` method.
+ 
+```java
+provider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
+```
+
+If you're not using Lock, then you'll have to handle the permission request result yourself. To do so, make your activity implement `ActivityCompat.OnRequestPermissionsResultCallback` and override the `onRequestPermissionsResult` method, calling `provider.onRequestPermissionsResult` with the activity context and the received parameters.
+
 ## Log out / Clear account.
 To log out the user so that the next time he's prompted to select an account call `clearSession`. After you do this the provider state will be invalid and you will need to call `start` again before trying to `authorize` a result.
 
 ```java
 provider.clearSession();
 ```
- 
+
 > Calling `stop` has the same effect.
 
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Android 4.0 or later & Google Play Services 9.+
 
 ## Before you start using Lock-Google
 
-In order to use Google APIs you'll need to register your Android application in [Google Developer Console](https://console.developers.google.com/project) and get your `web client id`.
-We recommend following Google's [quickstart](https://developers.google.com/mobile/add?platform=android), just pick `Google Sign-In`. Then generate a new `OAuth 2.0 client id` for a Web Application in the [Credentials](https://console.developers.google.com/apis/credentials?project=_) page. Take the value and use it to configure your Google Connection's `Client ID` in [Auth0 Dashboard](https://manage.auth0.com/#/connections/social). Save this value for later as it will be used in the android provider configuration.
+In order to use Google APIs you'll need to register your Android application in [Google Developer Console](https://console.developers.google.com/project) and get your `Web Client ID`.
+We recommend following Google's [quickstart](https://developers.google.com/mobile/add?platform=android), just pick `Google Sign-In`. Then generate a new `OAuth 2.0 Client ID` for a Web Application in the [Credentials](https://console.developers.google.com/apis/credentials?project=_) page. Take the value and use it to configure your Google Connection's `Client ID` in [Auth0 Dashboard](https://manage.auth0.com/#/connections/social). Save this value for later as it will be used in the android provider configuration.
 
 
 > For more information please check Google's [documentation](https://developers.google.com/identity/sign-in/android/)
@@ -27,10 +27,10 @@ If you also have a Web Application, and a Google clientID & secret for it config
 
 ## Install
 
-The Lock-GooglePlus is available through [Maven Central](http://search.maven.org) and [JCenter](https://bintray.com/bintray/jcenter). To install it, simply add the following line to your `build.gradle`:
+The Lock-Google is available through [Maven Central](http://search.maven.org) and [JCenter](https://bintray.com/bintray/jcenter). To install it, simply add the following line to your `build.gradle`:
 
 ```gradle
-compile 'com.auth0.android:lock-googleplus:2.5.+'
+compile 'com.auth0.android:lock-google:1.0.+'
 ```
 
 Then in your project's `AndroidManifest.xml` add the following entry inside the application tag.
@@ -60,11 +60,11 @@ This library includes an implementation of the `AuthHandler` interface for you t
  
 ```java
 Auth0 auth0 = new Auth0("auth0-client-id", "auth0-domain");
+AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
-GoogleAuthProvider provider = new GoogleAuthProvider(new AuthenticationAPIClient(auth0), "google-server-client-id");
+GoogleAuthProvider provider = new GoogleAuthProvider("google-server-client-id", client);
 provider.setScopes(new Scope(DriveScopes.DRIVE_METADATA_READONLY));
 provider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
-provider.forceRequestAccount(true);
 
 GoogleAuthHandler handler = new GoogleAuthHandler(provider);
 ```
@@ -84,12 +84,12 @@ That's it! When **Lock** needs to authenticate using that connection name, it wi
 
 ### Without Lock
 
-Just create a new instance of `GoogleAuthProvider` with an `AuthenticationAPIClient` and the `server client id` obtained in the Project Credential's page.
+Just create a new instance of `GoogleAuthProvider` with an `AuthenticationAPIClient` and the `Server Client ID` obtained in the Project Credential's page.
 
 ```java
 Auth0 auth0 = new Auth0("auth0-client-id", "auth0-domain");
-final AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-GoogleAuthProvider provider = new GoogleAuthProvider(client, "google-server-client-id");
+AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
+GoogleAuthProvider provider = new GoogleAuthProvider("google-server-client-id", client);
 ```
 
 Override your activity's `onActivityResult` method and redirect the received parameters to the provider instance's `authorize` method.
@@ -115,10 +115,10 @@ That's it! You'll receive the result in the `AuthCallback` you passed.
 > We provide this demo in the `SimpleActivity` class.
 
 ## Using a custom connection name
-To use a custom social connection name to authorize against Auth0, call `setConnection` with your new connection name.
+To use a custom social connection name to authorize against Auth0, create the GoogleAuthProvider instance using the second constructor:
 
 ```java
-provider.setConnection("my-connection")
+GoogleAuthProvider provider = new GoogleAuthProvider("my-connection", "google-server-client-id", client);
 ```
 
 ## Requesting a custom Scope
@@ -173,4 +173,4 @@ Auth0 helps you to:
 
 ## License
 
-Lock-GooglePlus is available under the MIT license. See the [LICENSE](LICENSE) file for more info.
+Lock-Google is available under the MIT license. See the [LICENSE](LICENSE) file for more info.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Lock lock = builder.withProviderResolver(authHandler);
 
 That's it! When **Lock** needs to authenticate using that connection name, it will ask the `AuthProviderResolver` for a valid `AuthProvider`.
 
+> We provide this demo in the `FilesActivity` class. We also use the Google Drive SDK to get the user's Drive Files and show them on a list. Because of the Drive Scope, the SDK requires the user to grant the `GET_ACCOUNTS` android permission first. Keep in mind that _this only affects this demo_ and that if you only need to authenticate the user and get his public profile, the `GoogleAuthProvider` won't ask for additional permissions.
+
 ### Without Lock
 
 Just create a new instance of `GoogleAuthProvider` with an `AuthenticationAPIClient` and the `server client id` obtained in the Project Credential's page.
@@ -117,6 +119,8 @@ provider.start(this, callback, RC_PERMISSIONS, RC_AUTHENTICATION);
 ```
 
 That's it! You'll receive the result in the `AuthCallback` you passed.
+
+> We provide this demo in the `SimpleActivity` class.
 
 ## Using a custom connection name
 To use a custom social connection name to authorize against Auth0, call `setConnection` with your new connection name.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '24.0.2'
 
     defaultConfig {
         applicationId 'com.auth0.android.google.app'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,5 +28,11 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-google')
     compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.auth0.android:lock:2.0.0'
+    compile 'com.auth0.android:lock:2.0.0-beta.3'
+    compile('com.google.apis:google-api-services-drive:v3-rev43-1.22.0') {
+        exclude group: 'org.apache.httpcomponents'
+    }
+    compile('com.google.api-client:google-api-client-android:1.22.0') {
+        exclude group: 'org.apache.httpcomponents'
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '24.0.2'
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         applicationId 'com.auth0.android.google.app'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,4 +28,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-google')
     compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.auth0.android:lock:2.0.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-google')
     compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.auth0.android:lock:2.0.0-beta.3'
+    compile 'com.auth0.android:lock:2.0.0'
     compile('com.google.apis:google-api-services-drive:v3-rev43-1.22.0') {
         exclude group: 'org.apache.httpcomponents'
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.auth0.google.app">
+    package="com.auth0.android.google.app">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 
     <application
         android:allowBackup="true"
@@ -11,13 +11,42 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.auth0.android.google.app.MainActivity">
+        <activity android:name=".ChooserActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.auth0.android.lock.LockActivity"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait"
+            android:theme="@style/Lock.Theme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="@string/com_auth0_domain"
+                    android:pathPrefix="/android/com.auth0.android.google.app/callback"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".SimpleActivity"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".FilesActivity"
+            android:screenOrientation="portrait" />
+
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/auth0/android/google/app/ChooserActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/ChooserActivity.java
@@ -1,0 +1,31 @@
+package com.auth0.android.google.app;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+
+public class ChooserActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chooser);
+        Button tokenLogin = (Button) findViewById(R.id.tokenLoginButton);
+        tokenLogin.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(ChooserActivity.this, SimpleActivity.class));
+            }
+        });
+        Button photosLogin = (Button) findViewById(R.id.photosLoginButton);
+        photosLogin.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(ChooserActivity.this, FilesActivity.class));
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
@@ -1,0 +1,189 @@
+package com.auth0.android.google.app;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.ProgressBar;
+
+import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.google.GoogleAuthProvider;
+import com.auth0.android.lock.AuthenticationCallback;
+import com.auth0.android.lock.Lock;
+import com.auth0.android.lock.LockCallback;
+import com.auth0.android.lock.provider.AuthProviderResolver;
+import com.auth0.android.lock.utils.LockException;
+import com.auth0.android.provider.AuthCallback;
+import com.auth0.android.provider.AuthProvider;
+import com.auth0.android.result.Credentials;
+import com.auth0.android.result.UserProfile;
+import com.google.android.gms.common.api.Scope;
+import com.google.api.client.extensions.android.http.AndroidHttp;
+import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.DriveScopes;
+import com.google.api.services.drive.model.File;
+import com.google.api.services.drive.model.FileList;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class FilesActivity extends AppCompatActivity {
+
+    private static final String TAG = FilesActivity.class.getSimpleName();
+    private static final String GOOGLE_CONNECTION = "google-oauth2";
+
+    private Lock lock;
+    private ProgressBar progressBar;
+    private ArrayList<String> files;
+    private ArrayAdapter<String> adapter;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_files);
+
+        lock = Lock.newBuilder(getAccount(), authCallback)
+                .withProviderResolver(providerResolver)
+                .onlyUseConnections(Collections.singletonList(GOOGLE_CONNECTION))
+                .closable(true)
+                .build();
+        lock.onCreate(this);
+
+
+        Button loginButton = (Button) findViewById(R.id.loginButton);
+        loginButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(lock.newIntent(FilesActivity.this));
+            }
+        });
+        progressBar = (ProgressBar) findViewById(R.id.progressBar);
+        ListView listView = (ListView) findViewById(R.id.list);
+        files = new ArrayList<>();
+        adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, files);
+        listView.setAdapter(adapter);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        lock.onDestroy(this);
+        lock = null;
+    }
+
+    private Auth0 getAccount() {
+        return new Auth0(getString(R.string.com_auth0_client_id), getString(R.string.com_auth0_domain));
+    }
+
+    private LockCallback authCallback = new AuthenticationCallback() {
+        @Override
+        public void onAuthentication(Credentials credentials) {
+            Log.i(TAG, "Auth ok! User has given us all google requested permissions.");
+            AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
+            client.tokenInfo(credentials.getIdToken())
+                    .start(new BaseCallback<UserProfile, AuthenticationException>() {
+                        @Override
+                        public void onSuccess(UserProfile payload) {
+                            final GoogleAccountCredential credential = GoogleAccountCredential.usingOAuth2(FilesActivity.this, Collections.singletonList(DriveScopes.DRIVE_METADATA_READONLY));
+                            credential.setSelectedAccountName(payload.getEmail());
+                            runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    new FetchFilesTask().execute(credential);
+                                }
+                            });
+                        }
+
+                        @Override
+                        public void onFailure(AuthenticationException error) {
+                        }
+                    });
+
+        }
+
+        @Override
+        public void onCanceled() {
+        }
+
+        @Override
+        public void onError(LockException error) {
+            Log.e(TAG, "Error occurred: " + error.getMessage());
+        }
+    };
+
+    private AuthProviderResolver providerResolver = new AuthProviderResolver() {
+        @Nullable
+        @Override
+        public AuthProvider onAuthProviderRequest(Context context, @NonNull AuthCallback callback, @NonNull String connectionName) {
+            if (GOOGLE_CONNECTION.equals(connectionName)) {
+                AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
+                GoogleAuthProvider googleProvider = new GoogleAuthProvider(client, getString(R.string.google_server_client_id));
+                googleProvider.setScopes(new Scope(DriveScopes.DRIVE_METADATA_READONLY));
+                googleProvider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
+                return googleProvider;
+            }
+            return null;
+        }
+    };
+
+    private class FetchFilesTask extends AsyncTask<GoogleAccountCredential, Void, List<String>> {
+
+        @Override
+        protected void onPreExecute() {
+            progressBar.setVisibility(View.VISIBLE);
+        }
+
+        @Override
+        protected List<String> doInBackground(GoogleAccountCredential... params) {
+            final Drive service = new Drive.Builder(
+                    AndroidHttp.newCompatibleTransport(),
+                    JacksonFactory.getDefaultInstance(),
+                    params[0])
+                    .setApplicationName("Auth0 Google Native Demo")
+                    .build();
+
+            List<String> fileInfo = new ArrayList<>();
+            FileList result;
+            try {
+                result = service.files().list()
+                        .setPageSize(30)
+                        .setFields("files(name, size)")
+                        .execute();
+                List<File> files = result.getFiles();
+                if (files != null) {
+                    for (File file : files) {
+                        if (file.getSize() != null) {
+                            fileInfo.add(String.format("[File] %s %s", file.getName(), file.getSize()));
+                        } else {
+                            fileInfo.add(String.format("[Folder] %s", file.getName()));
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return fileInfo;
+        }
+
+        @Override
+        protected void onPostExecute(List<String> names) {
+            files.addAll(names);
+            adapter.notifyDataSetChanged();
+            progressBar.setVisibility(View.GONE);
+        }
+    }
+}

--- a/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
@@ -1,9 +1,7 @@
 package com.auth0.android.google.app;
 
-import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -18,14 +16,12 @@ import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.google.GoogleAuthHandler;
 import com.auth0.android.google.GoogleAuthProvider;
 import com.auth0.android.lock.AuthenticationCallback;
 import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
-import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.utils.LockException;
-import com.auth0.android.provider.AuthCallback;
-import com.auth0.android.provider.AuthProvider;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.UserProfile;
 import com.google.android.gms.common.api.Scope;
@@ -57,13 +53,12 @@ public class FilesActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_files);
 
+        final GoogleAuthProvider provider = createGoogleAuthProvider();
         lock = Lock.newBuilder(getAccount(), authCallback)
-                .withProviderResolver(providerResolver)
-                .onlyUseConnections(Collections.singletonList(GOOGLE_CONNECTION))
+                .withAuthHandlers(new GoogleAuthHandler(provider))
+                .allowedConnections(Collections.singletonList(GOOGLE_CONNECTION))
                 .closable(true)
-                .build();
-        lock.onCreate(this);
-
+                .build(this);
 
         Button loginButton = (Button) findViewById(R.id.loginButton);
         loginButton.setOnClickListener(new View.OnClickListener() {
@@ -88,6 +83,14 @@ public class FilesActivity extends AppCompatActivity {
 
     private Auth0 getAccount() {
         return new Auth0(getString(R.string.com_auth0_client_id), getString(R.string.com_auth0_domain));
+    }
+
+    private GoogleAuthProvider createGoogleAuthProvider() {
+        GoogleAuthProvider provider = new GoogleAuthProvider(getString(R.string.google_server_client_id), new AuthenticationAPIClient(getAccount()));
+        provider.setScopes(new Scope(DriveScopes.DRIVE_METADATA_READONLY));
+        provider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
+        provider.forceRequestAccount(true);
+        return provider;
     }
 
     private LockCallback authCallback = new AuthenticationCallback() {
@@ -125,22 +128,6 @@ public class FilesActivity extends AppCompatActivity {
         public void onError(LockException error) {
             Toast.makeText(FilesActivity.this, "Error occurred. Please retry.", Toast.LENGTH_SHORT).show();
             Log.e(TAG, "Error occurred: " + error.getMessage());
-        }
-    };
-
-    private AuthProviderResolver providerResolver = new AuthProviderResolver() {
-        @Nullable
-        @Override
-        public AuthProvider onAuthProviderRequest(Context context, @NonNull AuthCallback callback, @NonNull String connectionName) {
-            if (GOOGLE_CONNECTION.equals(connectionName)) {
-                AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
-                GoogleAuthProvider googleProvider = new GoogleAuthProvider(getString(R.string.google_server_client_id), client);
-                googleProvider.setScopes(new Scope(DriveScopes.DRIVE_METADATA_READONLY));
-                googleProvider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
-                googleProvider.forceRequestAccount(true);
-                return googleProvider;
-            }
-            return null;
         }
     };
 

--- a/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
@@ -131,9 +131,10 @@ public class FilesActivity extends AppCompatActivity {
         public AuthProvider onAuthProviderRequest(Context context, @NonNull AuthCallback callback, @NonNull String connectionName) {
             if (GOOGLE_CONNECTION.equals(connectionName)) {
                 AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
-                GoogleAuthProvider googleProvider = new GoogleAuthProvider(client, getString(R.string.google_server_client_id));
+                GoogleAuthProvider googleProvider = new GoogleAuthProvider(getString(R.string.google_server_client_id), client);
                 googleProvider.setScopes(new Scope(DriveScopes.DRIVE_METADATA_READONLY));
                 googleProvider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
+                googleProvider.forceRequestAccount(true);
                 return googleProvider;
             }
             return null;

--- a/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
@@ -89,7 +89,7 @@ public class FilesActivity extends AppCompatActivity {
         GoogleAuthProvider provider = new GoogleAuthProvider(getString(R.string.google_server_client_id), new AuthenticationAPIClient(getAccount()));
         provider.setScopes(new Scope(DriveScopes.DRIVE_METADATA_READONLY));
         provider.setRequiredPermissions(new String[]{"android.permission.GET_ACCOUNTS"});
-        provider.forceRequestAccount(true);
+        provider.rememberLastLogin(false);
         return provider;
     }
 

--- a/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/FilesActivity.java
@@ -12,6 +12,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
@@ -117,10 +118,12 @@ public class FilesActivity extends AppCompatActivity {
 
         @Override
         public void onCanceled() {
+            Toast.makeText(FilesActivity.this, "Authentication cancelled", Toast.LENGTH_SHORT).show();
         }
 
         @Override
         public void onError(LockException error) {
+            Toast.makeText(FilesActivity.this, "Error occurred. Please retry.", Toast.LENGTH_SHORT).show();
             Log.e(TAG, "Error occurred: " + error.getMessage());
         }
     };
@@ -182,9 +185,14 @@ public class FilesActivity extends AppCompatActivity {
 
         @Override
         protected void onPostExecute(List<String> names) {
+            progressBar.setVisibility(View.GONE);
+            if (names.isEmpty()) {
+                Toast.makeText(FilesActivity.this, "You have no files on Google Drive!", Toast.LENGTH_LONG).show();
+                return;
+            }
+            files.clear();
             files.addAll(names);
             adapter.notifyDataSetChanged();
-            progressBar.setVisibility(View.GONE);
         }
     }
 }

--- a/app/src/main/java/com/auth0/android/google/app/SimpleActivity.java
+++ b/app/src/main/java/com/auth0/android/google/app/SimpleActivity.java
@@ -29,7 +29,6 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
@@ -42,12 +41,11 @@ import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.google.GoogleAuthProvider;
 import com.auth0.android.provider.AuthCallback;
 import com.auth0.android.result.Credentials;
-import com.auth0.google.app.R;
 
 
-public class MainActivity extends AppCompatActivity implements View.OnClickListener {
+public class SimpleActivity extends AppCompatActivity implements View.OnClickListener {
 
-    private static final String TAG = MainActivity.class.getName();
+    private static final String TAG = SimpleActivity.class.getName();
     private static final int RC_PERMISSIONS = 110;
     private static final int RC_AUTHENTICATION = 111;
 
@@ -58,7 +56,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        setContentView(R.layout.activity_simple);
 
         message = (TextView) findViewById(R.id.textView);
         Button loginButton = (Button) findViewById(R.id.loginButton);
@@ -87,7 +85,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        AlertDialog dialog = new AlertDialog.Builder(MainActivity.this)
+                        AlertDialog dialog = new AlertDialog.Builder(SimpleActivity.this)
                                 .setTitle("Failed!")
                                 .setMessage(exception.getLocalizedMessage())
                                 .create();

--- a/app/src/main/res/layout/activity_chooser.xml
+++ b/app/src/main/res/layout/activity_chooser.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ activity_main.xml
+  ~ activity_chooser.xml
   ~
   ~ Copyright (c) 2015 Auth0 (http://auth0.com)
   ~
@@ -29,30 +29,30 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.auth0.android.google.app.MainActivity">
+    tools:context=".SimpleActivity">
 
     <TextView
-        android:id="@+id/textView"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/loginButton"
+        android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
-        android:layout_marginBottom="20dp"
         android:gravity="center_horizontal"
+        android:text="This demo shows how to log in using the Google Native Social Authentication Provider."
         android:textSize="20sp" />
 
     <Button
-        android:id="@+id/loginButton"
+        android:id="@+id/tokenLoginButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:text="Log in with Google" />
+        android:text="Simple Log In (TOKEN)" />
 
     <Button
-        android:id="@+id/logoutButton"
+        android:id="@+id/photosLoginButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
+        android:layout_below="@id/tokenLoginButton"
         android:layout_centerHorizontal="true"
-        android:text="Log out" />
+        android:text="Log In Using Lock (DRIVE FILES)" />
+
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_files.xml
+++ b/app/src/main/res/layout/activity_files.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ activity_photos.xml
+  ~
+  ~ Copyright (c) 2015 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".SimpleActivity">
+
+    <Button
+        android:id="@+id/loginButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:text="Log in with Google" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="@style/Base.Widget.AppCompat.ProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:indeterminate="true"
+        android:visibility="invisible" />
+
+    <ListView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/loginButton" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_simple.xml
+++ b/app/src/main/res/layout/activity_simple.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ activity_simple.xml
+  ~
+  ~ Copyright (c) 2015 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.auth0.android.google.app.SimpleActivity">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/loginButton"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="20dp"
+        android:gravity="center_horizontal"
+        android:textSize="20sp" />
+
+    <Button
+        android:id="@+id/loginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="Log in with Google" />
+
+    <Button
+        android:id="@+id/logoutButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:text="Log out" />
+</RelativeLayout>

--- a/app/src/main/res/values/auth0.xml
+++ b/app/src/main/res/values/auth0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="com_auth0_client_id" translatable="false">Owu62gnGsRYhk1v9SfB3c6IUbIJcRIze</string>
+    <string name="com_auth0_client_id" translatable="false">hGou2NwxDfWEPI93dfcI7yilPf8ZPbfD</string>
     <string name="com_auth0_domain" translatable="false">lbalmaceda.auth0.com</string>
 </resources>

--- a/lock-google/build.gradle
+++ b/lock-google/build.gradle
@@ -7,7 +7,7 @@ logger.lifecycle("Using version ${version} for ${name}")
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         minSdkVersion 15

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAPI.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAPI.java
@@ -173,6 +173,9 @@ class GoogleAPI implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.
         client = null;
     }
 
+    /**
+     * Logs out the current signed in account.
+     */
     void logout() {
         try {
             Auth.GoogleSignInApi.signOut(client).setResultCallback(new ResultCallback<Status>() {
@@ -186,6 +189,16 @@ class GoogleAPI implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.
         } catch (IllegalStateException e) {
             Log.e(TAG, "Failed to clear the Google Plus Session", e);
         }
+    }
+
+    /**
+     * Disconnects the current GoogleAPIClient instance. After this method is called the provider should not be used.
+     */
+    void disconnect() {
+        if (client != null && client.isConnected()) {
+            client.disconnect();
+        }
+        client = null;
     }
 
     private GoogleApiClient createGoogleAPIClient(String serverClientId, Scope[] scopes) {

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAPI.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAPI.java
@@ -33,7 +33,7 @@ class GoogleAPI implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.
     private boolean resolvingError;
     private int signInRequestCode;
     private int errorResolutionRequestCode;
-    private boolean forceRequestAccount;
+    private boolean rememberLastLogin;
 
     /**
      * @param activity       a valid activity context to use
@@ -50,10 +50,10 @@ class GoogleAPI implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.
     /**
      * Whether it should clear the session and logout any existing user before trying to authenticate or not.
      *
-     * @param forceRequestAccount the new force flag value.
+     * @param rememberLastLogin the new force flag value.
      */
-    public void forceRequestAccount(boolean forceRequestAccount) {
-        this.forceRequestAccount = forceRequestAccount;
+    public void rememberLastLogin(boolean rememberLastLogin) {
+        this.rememberLastLogin = rememberLastLogin;
     }
 
     @Override
@@ -205,7 +205,7 @@ class GoogleAPI implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.
 
 
     private void requestGoogleAccount(int signInRequestCode) {
-        if (forceRequestAccount) {
+        if (!rememberLastLogin) {
             logout();
         }
         final Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(client);

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
@@ -1,0 +1,30 @@
+package com.auth0.android.google;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.provider.AuthHandler;
+import com.auth0.android.provider.AuthProvider;
+
+public class GoogleAuthHandler implements AuthHandler {
+
+    private final GoogleAuthProvider provider;
+
+    public GoogleAuthHandler(@NonNull AuthenticationAPIClient apiClient, @NonNull String serverClientId) {
+        this(new GoogleAuthProvider(serverClientId, apiClient));
+    }
+
+    public GoogleAuthHandler(@NonNull GoogleAuthProvider provider) {
+        this.provider = provider;
+    }
+
+    @Nullable
+    @Override
+    public AuthProvider providerFor(@NonNull String strategy, @NonNull String connection) {
+        if ("google-oauth2".equals(connection)) {
+            return provider;
+        }
+        return null;
+    }
+}

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
@@ -7,14 +7,30 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.provider.AuthHandler;
 import com.auth0.android.provider.AuthProvider;
 
+/**
+ * AuthHandler class to handle the Authentication flow using the Google Android SDK.
+ * By default, all the authentication requests to this provider with the strategy "google-oauth2" will be handled.
+ */
 public class GoogleAuthHandler implements AuthHandler {
 
     private final GoogleAuthProvider provider;
 
+    /**
+     * Creates a new instance of this AuthHandler with the given Auth0 AuthenticationAPIClient and the Google Server Client ID.
+     * For more information about how to setup the Google Project and obtain the Server Client ID, check the README.md file.
+     *
+     * @param apiClient      Auth0 api client to perform the authentication request with.
+     * @param serverClientId the Google Server Client ID to begin the id_token request with.
+     */
     public GoogleAuthHandler(@NonNull AuthenticationAPIClient apiClient, @NonNull String serverClientId) {
         this(new GoogleAuthProvider(serverClientId, apiClient));
     }
 
+    /**
+     * Creates a new instance of this AuthHandler with the given GoogleAuthProvider.
+     *
+     * @param provider provider to return in the providerFor() requests.
+     */
     public GoogleAuthHandler(@NonNull GoogleAuthProvider provider) {
         this.provider = provider;
     }

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
@@ -21,8 +21,8 @@ public class GoogleAuthHandler implements AuthHandler {
 
     @Nullable
     @Override
-    public AuthProvider providerFor(@NonNull String strategy, @NonNull String connection) {
-        if ("google-oauth2".equals(connection)) {
+    public AuthProvider providerFor(@Nullable String strategy, @NonNull String connection) {
+        if ("google-oauth2".equals(strategy)) {
             return provider;
         }
         return null;

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
@@ -43,6 +43,7 @@ public class GoogleAuthProvider extends AuthProvider {
 
     /**
      * Creates Google Auth provider for default Google connection 'google-oauth2'.
+     *
      * @param client         an Auth0 AuthenticationAPIClient instance
      * @param serverClientId the OAuth 2.0 server client id obtained when creating a new credential on the Google API's console.
      */
@@ -52,6 +53,7 @@ public class GoogleAuthProvider extends AuthProvider {
 
     /**
      * Creates Google Auth provider for a specific Google connection.
+     *
      * @param connectionName of Auth0's connection used to Authenticate after user is authenticated with Google. Must be a Google connection
      * @param serverClientId the OAuth 2.0 server client id obtained when creating a new credential on the Google API's console.
      * @param client         an Auth0 AuthenticationAPIClient instance

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
@@ -101,6 +101,9 @@ public class GoogleAuthProvider extends AuthProvider {
 
     @Override
     protected void requestAuth(Activity activity, int requestCode) {
+        if (google != null) {
+            google.disconnect();
+        }
         google = createGoogleAPI(activity, rememberLastLogin);
         final int availabilityStatus = google.isGooglePlayServicesAvailable();
         if (availabilityStatus == ConnectionResult.SUCCESS) {

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
@@ -40,7 +40,7 @@ public class GoogleAuthProvider extends AuthProvider {
     private Scope[] scopes;
     private GoogleAPI google;
     private String[] androidPermissions;
-    private boolean forceRequestAccount;
+    private boolean rememberLastLogin;
 
     /**
      * Creates Google Auth provider for default Google connection 'google-oauth2'.
@@ -65,6 +65,7 @@ public class GoogleAuthProvider extends AuthProvider {
         this.scopes = new Scope[]{new Scope(Scopes.PLUS_LOGIN)};
         this.connectionName = connectionName;
         this.androidPermissions = new String[0];
+        this.rememberLastLogin = true;
     }
 
     /**
@@ -80,11 +81,12 @@ public class GoogleAuthProvider extends AuthProvider {
     /**
      * Whether it should clear the session and logout any existing user before trying to authenticate or not.
      * This can be useful when using Lock, so that the user always need to select which account/credentials to use.
+     * Defaults to true.
      *
-     * @param force the new force flag value.
+     * @param rememberLastLogin the new flag value.
      */
-    public void forceRequestAccount(boolean force) {
-        this.forceRequestAccount = force;
+    public void rememberLastLogin(boolean rememberLastLogin) {
+        this.rememberLastLogin = rememberLastLogin;
     }
 
     /**
@@ -99,7 +101,7 @@ public class GoogleAuthProvider extends AuthProvider {
 
     @Override
     protected void requestAuth(Activity activity, int requestCode) {
-        google = createGoogleAPI(activity, forceRequestAccount);
+        google = createGoogleAPI(activity, rememberLastLogin);
         final int availabilityStatus = google.isGooglePlayServicesAvailable();
         if (availabilityStatus == ConnectionResult.SUCCESS) {
             google.connectAndRequestGoogleAccount(requestCode, REQUEST_RESOLVE_ERROR);
@@ -165,9 +167,9 @@ public class GoogleAuthProvider extends AuthProvider {
         return connectionName;
     }
 
-    GoogleAPI createGoogleAPI(Activity activity, boolean forceRequestAccount) {
+    GoogleAPI createGoogleAPI(Activity activity, boolean rememberLastLogin) {
         final GoogleAPI googleAPI = new GoogleAPI(activity, serverClientId, scopes, createTokenListener());
-        googleAPI.forceRequestAccount(forceRequestAccount);
+        googleAPI.rememberLastLogin(rememberLastLogin);
         return googleAPI;
     }
 

--- a/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
+++ b/lock-google/src/main/java/com/auth0/android/google/GoogleAuthProvider.java
@@ -40,6 +40,7 @@ public class GoogleAuthProvider extends AuthProvider {
     private Scope[] scopes;
     private GoogleAPI google;
     private String[] androidPermissions;
+    private boolean forceRequestAccount;
 
     /**
      * Creates Google Auth provider for default Google connection 'google-oauth2'.
@@ -77,6 +78,16 @@ public class GoogleAuthProvider extends AuthProvider {
     }
 
     /**
+     * Whether it should clear the session and logout any existing user before trying to authenticate or not.
+     * This can be useful when using Lock, so that the user always need to select which account/credentials to use.
+     *
+     * @param force the new force flag value.
+     */
+    public void forceRequestAccount(boolean force) {
+        this.forceRequestAccount = force;
+    }
+
+    /**
      * Change the scopes to request on the user login. Use any of the scopes defined in the com.google.android.gms.common.Scopes class. Must be called before start().
      * The scope Scopes.PLUG_LOGIN is requested by default.
      *
@@ -88,7 +99,7 @@ public class GoogleAuthProvider extends AuthProvider {
 
     @Override
     protected void requestAuth(Activity activity, int requestCode) {
-        google = createAPIHelper(activity);
+        google = createGoogleAPI(activity, forceRequestAccount);
         final int availabilityStatus = google.isGooglePlayServicesAvailable();
         if (availabilityStatus == ConnectionResult.SUCCESS) {
             google.connectAndRequestGoogleAccount(requestCode, REQUEST_RESOLVE_ERROR);
@@ -154,8 +165,10 @@ public class GoogleAuthProvider extends AuthProvider {
         return connectionName;
     }
 
-    GoogleAPI createAPIHelper(Activity activity) {
-        return new GoogleAPI(activity, serverClientId, scopes, createTokenListener());
+    GoogleAPI createGoogleAPI(Activity activity, boolean forceRequestAccount) {
+        final GoogleAPI googleAPI = new GoogleAPI(activity, serverClientId, scopes, createTokenListener());
+        googleAPI.forceRequestAccount(forceRequestAccount);
+        return googleAPI;
     }
 
     GoogleCallback createTokenListener() {

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
@@ -8,6 +8,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 public class GoogleAuthProviderMock extends GoogleAuthProvider {
     GoogleAPI apiHelper;
     GoogleCallback googleCallback;
+    boolean logoutBeforeLogin;
 
     public GoogleAuthProviderMock(@NonNull String connectionName, @NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI apiHelper) {
         super(connectionName, serverClientId, client);
@@ -20,8 +21,9 @@ public class GoogleAuthProviderMock extends GoogleAuthProvider {
     }
 
     @Override
-    GoogleAPI createAPIHelper(Activity activity) {
+    GoogleAPI createGoogleAPI(Activity activity, boolean forceRequestAccount) {
         createTokenListener();
+        this.logoutBeforeLogin = forceRequestAccount;
         return apiHelper;
     }
 
@@ -29,5 +31,9 @@ public class GoogleAuthProviderMock extends GoogleAuthProvider {
     GoogleCallback createTokenListener() {
         googleCallback = super.createTokenListener();
         return googleCallback;
+    }
+
+    boolean willLogoutBeforeLogin() {
+        return logoutBeforeLogin;
     }
 }

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
@@ -6,25 +6,25 @@ import android.support.annotation.NonNull;
 import com.auth0.android.authentication.AuthenticationAPIClient;
 
 public class GoogleAuthProviderMock extends GoogleAuthProvider {
-    GoogleAPI apiHelper;
+    GoogleAPI google;
     GoogleCallback googleCallback;
     boolean logoutBeforeLogin;
 
-    public GoogleAuthProviderMock(@NonNull String connectionName, @NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI apiHelper) {
+    public GoogleAuthProviderMock(@NonNull String connectionName, @NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI google) {
         super(connectionName, serverClientId, client);
-        this.apiHelper = apiHelper;
+        this.google = google;
     }
 
-    public GoogleAuthProviderMock(@NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI apiHelper) {
+    public GoogleAuthProviderMock(@NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI google) {
         super(serverClientId, client);
-        this.apiHelper = apiHelper;
+        this.google = google;
     }
 
     @Override
     GoogleAPI createGoogleAPI(Activity activity, boolean forceRequestAccount) {
         createTokenListener();
         this.logoutBeforeLogin = forceRequestAccount;
-        return apiHelper;
+        return google;
     }
 
     @Override

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
@@ -10,12 +10,12 @@ public class GoogleAuthProviderMock extends GoogleAuthProvider {
     GoogleCallback googleCallback;
     boolean rememberLastLogin;
 
-    public GoogleAuthProviderMock(@NonNull String connectionName, @NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI google) {
+    public GoogleAuthProviderMock(@NonNull String connectionName, @NonNull String serverClientId, @NonNull AuthenticationAPIClient client, @NonNull GoogleAPI google) {
         super(connectionName, serverClientId, client);
         this.google = google;
     }
 
-    public GoogleAuthProviderMock(@NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI google) {
+    public GoogleAuthProviderMock(@NonNull String serverClientId, @NonNull AuthenticationAPIClient client, @NonNull GoogleAPI google) {
         super(serverClientId, client);
         this.google = google;
     }

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderMock.java
@@ -8,7 +8,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 public class GoogleAuthProviderMock extends GoogleAuthProvider {
     GoogleAPI google;
     GoogleCallback googleCallback;
-    boolean logoutBeforeLogin;
+    boolean rememberLastLogin;
 
     public GoogleAuthProviderMock(@NonNull String connectionName, @NonNull String serverClientId, @NonNull AuthenticationAPIClient client, GoogleAPI google) {
         super(connectionName, serverClientId, client);
@@ -21,9 +21,9 @@ public class GoogleAuthProviderMock extends GoogleAuthProvider {
     }
 
     @Override
-    GoogleAPI createGoogleAPI(Activity activity, boolean forceRequestAccount) {
+    GoogleAPI createGoogleAPI(Activity activity, boolean rememberLastLogin) {
         createTokenListener();
-        this.logoutBeforeLogin = forceRequestAccount;
+        this.rememberLastLogin = rememberLastLogin;
         return google;
     }
 
@@ -34,6 +34,6 @@ public class GoogleAuthProviderMock extends GoogleAuthProvider {
     }
 
     boolean willLogoutBeforeLogin() {
-        return logoutBeforeLogin;
+        return !rememberLastLogin;
     }
 }

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderTest.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderTest.java
@@ -183,7 +183,7 @@ public class GoogleAuthProviderTest {
 
     @Test
     public void shouldLogoutBeforeLoginIfRequested() throws Exception {
-        provider.forceRequestAccount(true);
+        provider.rememberLastLogin(false);
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         assertThat(provider.willLogoutBeforeLogin(), is(true));
     }

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderTest.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderTest.java
@@ -19,7 +19,6 @@ import com.google.android.gms.common.api.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsArrayContaining;
 import org.hamcrest.collection.IsArrayWithSize;
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -103,12 +102,19 @@ public class GoogleAuthProviderTest {
 
     @Test
     public void shouldHaveNonNullConnectionName() throws Exception {
-        MatcherAssert.assertThat(provider.getConnection(), Is.is(notNullValue()));
+        MatcherAssert.assertThat(provider.getConnection(), is(notNullValue()));
     }
 
     @Test
     public void shouldHaveDefaultConnectionName() throws Exception {
-        MatcherAssert.assertThat(provider.getConnection(), Is.is(CONNECTION_NAME));
+        MatcherAssert.assertThat(provider.getConnection(), is(CONNECTION_NAME));
+    }
+
+    @Test
+    public void shouldCreateWithCustomConnectionName() throws Exception {
+        provider = new GoogleAuthProviderMock("custom-connection", SERVER_CLIENT_ID, client, google);
+        MatcherAssert.assertThat(provider.getConnection(), is(notNullValue()));
+        MatcherAssert.assertThat(provider.getConnection(), is("custom-connection"));
     }
 
     @Test
@@ -203,7 +209,7 @@ public class GoogleAuthProviderTest {
     }
 
     @Test
-    public void shouldFailWithTextWhenSomeScopesWereRejected() throws Exception {
+    public void shouldFailWithExceptionWhenSomeScopesWereRejected() throws Exception {
         provider.setScopes(new Scope("some-scope"));
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
 
@@ -244,7 +250,7 @@ public class GoogleAuthProviderTest {
     }
 
     @Test
-    public void shouldFailWithTextWhenFacebookRequestIsCancelled() throws Exception {
+    public void shouldFailWithExceptionWhenRequestIsCancelled() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.googleCallback.onCancel();
 
@@ -252,7 +258,7 @@ public class GoogleAuthProviderTest {
     }
 
     @Test
-    public void shouldFailWithTextWhenCredentialsRequestFailed() {
+    public void shouldFailWithExceptionWhenCredentialsRequestFailed() {
         shouldFailRequest(authenticationRequest);
         when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME))
                 .thenReturn(authenticationRequest);

--- a/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderTest.java
+++ b/lock-google/src/test/java/com/auth0/android/google/GoogleAuthProviderTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class GoogleAuthProviderTest {
 
@@ -277,6 +278,13 @@ public class GoogleAuthProviderTest {
         provider.googleCallback.onSuccess(createGoogleSignInAccountFromToken(TOKEN, new HashSet<>(Arrays.asList(provider.getScopes()))));
 
         verify(callback).onSuccess(eq(credentials));
+    }
+
+    @Test
+    public void shouldDisconnectGoogleClientBeforeReUsing() throws Exception {
+        provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
+        provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
+        verify(google, times(1)).disconnect();
     }
 
     @Test

--- a/lock-googleplus/build.gradle
+++ b/lock-googleplus/build.gradle
@@ -1,0 +1,36 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion compile.maxSdk
+    buildToolsVersion compile.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion compile.minSdk
+        targetSdkVersion compile.maxSdk
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
+    lintOptions {
+        lintConfig file('../gradle/lint.xml')
+    }
+}
+
+dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile libraries.app_compat
+    compile 'com.google.android.gms:play-services-auth:9.4.0'
+    compile 'com.auth0.android:auth0:1.0.0-rc.1-SNAPSHOT'
+    testCompile libraries.testing
+}
+
+apply from: '../maven_push.gradle'

--- a/lock-googleplus/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
+++ b/lock-googleplus/src/main/java/com/auth0/android/google/GoogleAuthHandler.java
@@ -1,0 +1,30 @@
+package com.auth0.android.google;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.provider.AuthHandler;
+import com.auth0.android.provider.AuthProvider;
+
+public class GoogleAuthHandler implements AuthHandler {
+
+    private final GoogleAuthProvider provider;
+
+    public GoogleAuthHandler(@NonNull AuthenticationAPIClient apiClient, @NonNull String serverClientId) {
+        this(new GoogleAuthProvider(apiClient, serverClientId));
+    }
+
+    public GoogleAuthHandler(@NonNull GoogleAuthProvider provider) {
+        this.provider = provider;
+    }
+
+    @Nullable
+    @Override
+    public AuthProvider providerFor(@NonNull String strategy, @NonNull String connection) {
+        if ("google-oauth2".equals(connection)) {
+            return provider;
+        }
+        return null;
+    }
+}

--- a/lock-googleplus/src/test/java/com/auth0/android/google/GoogleAuthHandlerTest.java
+++ b/lock-googleplus/src/test/java/com/auth0/android/google/GoogleAuthHandlerTest.java
@@ -1,0 +1,41 @@
+package com.auth0.android.google;
+
+import com.auth0.android.provider.AuthProvider;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class GoogleAuthHandlerTest {
+
+    private GoogleAuthProvider provider;
+    private GoogleAuthHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        provider = mock(GoogleAuthProvider.class);
+        handler = new GoogleAuthHandler(provider);
+    }
+
+    @Test
+    public void shouldGetFacebookProvider() throws Exception {
+        final AuthProvider p = handler.providerFor("google-oauth2", "google-oauth2");
+        assertThat(p, is(notNullValue()));
+        assertThat(p, is(CoreMatchers.instanceOf(GoogleAuthProvider.class)));
+        assertThat(p, is(equalTo((AuthProvider) provider)));
+    }
+
+    @Test
+    public void shouldGetNullProvider() throws Exception {
+        final AuthProvider p = handler.providerFor("some-strategy", "some-connection");
+        assertThat(p, is(nullValue()));
+    }
+
+}

--- a/scripts/bintray.gradle
+++ b/scripts/bintray.gradle
@@ -11,8 +11,8 @@ if (hasProperty('bintray.user') && hasProperty('bintray.key') && hasProperty('bi
         publish = false
         pkg {
             repo = 'lock-android'
-            name = 'Auth0.Android'
-            desc = 'Android toolkit for Auth0 API'
+            name = 'lock-google'
+            desc = 'Lock for Android add-on to use Google Android SDK'
             websiteUrl = 'https://github.com/auth0/auth0.android'
             vcsUrl = 'scm:git@github.com:auth0/auth0.android.git'
             licenses = ["MIT"]


### PR DESCRIPTION
Split the demo activity in two:
1) `SimpleActivity` shows *Log in* and *Log out* buttons, and displays the user access_token when the user logs in.
2) `FilesActivity` shows a *Log in* button to open **Lock** and authenticate with Google (also native). After the user logs in, a list will be populated with his drive files.

The class `GoogleAuthHandler` is provided implementing the `AuthHandler` interface, so the dev can use it directly with **Lock**. It has 2 constructors: 
* one receiving the `AuthProvider` instance, for him to customize it (scopes, permissions, etc) before instantiating the AuthHandler.
* one receiving the google `serverClientId` and the Auth0 `apiClient`, if the user doesn't want to customize anything.